### PR TITLE
CMS-7498 : "agentlib" debug line in workbench jvm config

### DIFF
--- a/perc-devtools-distribution/src/main/resources/scripts/Workbench.cmd
+++ b/perc-devtools-distribution/src/main/resources/scripts/Workbench.cmd
@@ -1,24 +1,20 @@
 @echo off
 echo Java Version:
 java -version
+
+ECHO "Prod command example: Workbench.cmd"
+ECHO "Dev command example: Workbench.cmd dev <port_number>"
+
 IF "%1"=="" (
-  ECHO Invalid argument: %1
-  ECHO.
-  ECHO Usage:  %~n0  command
-  ECHO.
-  ECHO Where:  command may be prod, dev
-  ECHO Where:  prod is without debug port enabled suitable for production and dev is with debug port enabled suitable for developers
-  ECHO "Prod command example: Workbench.cmd prod"
-  ECHO "Dev command example: Workbench.cmd dev <port_number>"
-  GOTO:EOF
+  goto PROD
 )
+
 IF "%1"=="dev" (
 	if "%2"=="" (
 		ECHO please provide valid debug port number
 		goto end
-	)
+	) else (goto DEV)
 )
-if "%1"=="prod" (goto PROD) else (goto DEV)
 goto end
 
 :PROD

--- a/perc-devtools-distribution/src/main/resources/scripts/Workbench.sh
+++ b/perc-devtools-distribution/src/main/resources/scripts/Workbench.sh
@@ -1,7 +1,10 @@
-#!/bin/bash -bm
-source DevOptions.sh
+#!/usr/bin/env bash
+
 echo "Using Java version:"
 java -version
+
+echo "Prod command example: Workbench.cmd prod"
+echo "Dev command example: Workbench.cmd dev <port_number>"
 
 unameOut="$(uname -s)"
 case "${unameOut}" in
@@ -14,19 +17,8 @@ esac
 echo ${machine}
 
 if ["$1"==""]; then
-	usage
+	prod = true
 fi
-
-function usage() {
-  echo "Usage: $0 {prod | dev}"
-  echo "Where:  command may be prod, dev"
-  echo "Where:  prod is without debug port enabled suitable for production and dev is with debug port enabled suitable for developers"
-  echo "Provide Valid <port_number> if using dev mode"
-  echo "Prod command example: Workbench.cmd prod"
-  echo "Dev command example: Workbench.cmd dev <port_number>"
-  exit 1
-}
-
 
 if ["$1"=="dev"]; then
 	devUsage
@@ -46,14 +38,14 @@ function checkPort() {
 if [[ ${machine} -eq "Mac" ]]
 then
   chmod +x ./workbench/Eclipse.app/Contents/MacOS/eclipse
-  if ["$1"=="prod"]; then
+  if ["$prod"=="true"]; then
 	./workbench/Eclipse.app/Contents/MacOS/eclipse
   else
 	./workbench/Eclipse.app/Contents/MacOS/eclipse --launcher.stickyVmargs -vmargs -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=$2
   fi
 else
   chmod +x ./workbench/eclipse
-  if ["$1"=="prod"]; then
+  if ["$prod"=="true"]; then
 	./workbench/eclipse
   else
 	./workbench/eclipse --launcher.stickyVmargs -vmargs -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=$2


### PR DESCRIPTION
 A way for developers to not have to manually edit eclipse.ini after every build / install.
 We have to pass prod / dev as options while executing the command. If dev is passed then need to specify a valid port number for debug.